### PR TITLE
Corrected library name in example from HX711 to HX711ADC

### DIFF
--- a/firmware/examples/HX711Serial.ino
+++ b/firmware/examples/HX711Serial.ino
@@ -1,9 +1,9 @@
-#include "HX711.h"
+#include "HX711ADC.h"
 
 // HX711.DOUT	- pin #A1
 // HX711.PD_SCK	- pin #A0
 
-HX711 scale(A1, A0);		// parameter "gain" is ommited; the default value 128 is used by the library
+HX711ADC scale(A1, A0);		// parameter "gain" is ommited; the default value 128 is used by the library
 
 void setup() {
   Serial.begin(38400);


### PR DESCRIPTION
When importing the library and trying to use the sample code in Particle Build, it fails to compile because the library name doesn't match.
